### PR TITLE
chore: pin ubuntu version to `22.04`

### DIFF
--- a/.github/workflows/third_party_checks.yml
+++ b/.github/workflows/third_party_checks.yml
@@ -11,7 +11,7 @@ name: third_party_checks
 jobs:
   third_party_checks:
     name: Build (sonarCloud)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       SONAR_SERVER_URL: "https://sonarcloud.io"
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory


### PR DESCRIPTION
Problem with installing gcovr without venv.

Cf. https://github.com/vil02/CtUnits/actions/runs/11301368158/job/31441962719?pr=145